### PR TITLE
feat -> use the same condition as in the property declaration

### DIFF
--- a/src/ios/EMMAPlugin.m
+++ b/src/ios/EMMAPlugin.m
@@ -81,7 +81,9 @@ enum ActionTypes {
 
 -(void) setNotificationDelegate:(id<UNUserNotificationCenterDelegate>)delegate {
     if (delegate) {
+        #if defined(__IPHONE_10_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0 && PUSH_ENABLED == 1
         self.pushDelegate = delegate;
+        #endif
         [[UNUserNotificationCenter currentNotificationCenter] setDelegate:delegate];
     }
 }


### PR DESCRIPTION
Solution for issue #1: https://github.com/EMMADevelopment/Cordova-Plugin-EMMA-SDK/issues/1

Fails because the property pushDelegate not found.

<img width="1118" alt="captura_de_pantalla_2022-07-08_a_las_14 00 40" src="https://user-images.githubusercontent.com/84543810/177994316-53ad8b9c-4e99-426e-97a4-b3ec28df5d3e.png">

